### PR TITLE
Add static matrix factorization for GPU

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 GPUifyLoops = "ba82f77b-6841-5d2e-bd9f-4daf811aec27"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"
@@ -18,4 +19,4 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq","Test"]
+test = ["OrdinaryDiffEq", "Test"]

--- a/src/DiffEqGPU.jl
+++ b/src/DiffEqGPU.jl
@@ -206,7 +206,7 @@ function (p::LinSolveGPUSplitFactorize{T,L})(x,A,b,update_matrix=false;kwargs...
     @launch version qr_kernel(p.facts,A,L,SArray{Tuple{L,L},Float32,2,L*L})
   end
   copyto!(x, b)
-  @launch version ldiv!_kernel(p.facts,x,L)
+  @launch version ldiv!_kernel(p.facts,x,L,SArray{Tuple{L},Float32,1,L})
   return nothing
 end
 function (p::LinSolveGPUSplitFactorize)(::Type{Val{:init}},f,u0_prototype)
@@ -216,21 +216,22 @@ function (p::LinSolveGPUSplitFactorize)(::Type{Val{:init}},f,u0_prototype)
 end
 
 function qr_kernel(facts,W,len,::Type{T}) where T
+    n = StaticArrays.Length(T)
     @loop for i in (0:length(facts)-1; (blockIdx().x-1) * blockDim().x + threadIdx().x)
         section = 1 + (i*len) : ((i+1)*len)
         #facts[i+1] = qr(@inbounds T(@view W[section, section]))
-        facts[i+1] = @inbounds T(@view W[section, section])
+        facts[i+1] = StaticArrays._convert(T, (@view W[section, section]), n)
         nothing
     end
     return nothing
 end
 
-function ldiv!_kernel(facts,x,len)
-    T = SArray{Tuple{3},Float32,1,3}
+function ldiv!_kernel(facts,x,len,::Type{T}) where T
+    n = StaticArrays.Length(T)
     @loop for i in (0:length(facts)-1; (blockIdx().x-1) * blockDim().x + threadIdx().x)
         section = 1 + (i*len) : ((i+1)*len)
         xi = @view x[section]
-        xi .= facts[i+1] \ @inbounds T(xi)
+        xi .= facts[i+1] \ StaticArrays._convert(T, xi, n)
         nothing
     end
     return nothing


### PR DESCRIPTION
```julia
using DiffEqGPU, CuArrays, OrdinaryDiffEq

function lorenz(du,u,p,t)
 @inbounds begin
     du[1] = p[1]*(u[2]-u[1])
     du[2] = u[1]*(p[2]-u[3]) - u[2]
     du[3] = u[1]*u[2] - p[3]*u[3]
 end
 nothing
end

CuArrays.allowscalar(false)
u0 = Float32[1.0;0.0;0.0]
tspan = (0.0f0,100.0f0)
p = (10.0f0,28.0f0,8/3f0)
prob = ODEProblem(lorenz,u0,tspan,p)
const pre_p = [rand(Float32,3) for i in 1:100_000]
prob_func = (prob,i,repeat) -> remake(prob,p=pre_p[i].*p)
monteprob = EnsembleProblem(prob, prob_func = prob_func)
solve(monteprob,TRBDF2(linsolve=LinSolveGPUSplitFactorize()),EnsembleGPUArray(),dt=0.1,trajectories=2,saveat=1.0f0)
```

The compilation fails with

```julia
julia> @time solve(monteprob,TRBDF2(linsolve=LinSolveGPUSplitFactorize()),EnsembleGPUArray(),dt=0.1,trajectories=20,saveat=1.0f0);
ERROR: BoundsError: attempt to access Core.SimpleVector
  at index [7]
Stacktrace:
 [1] indexed_iterate(::Core.SimpleVector, ::Int64, ::Int64) at ./tuple.jl:72
 [2] check_ir!(::CUDAnative.CompilerJob, ::Array{Tuple{String,Array{Base.StackTraces.StackFrame,1},Any},1}, ::LLVM.CallInst) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/validation.jl:267
 [3] check_ir!(::CUDAnative.CompilerJob, ::Array{Tuple{String,Array{Base.StackTraces.StackFrame,1},Any},1}, ::LLVM.Function) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/validation.jl:131
 [4] check_ir!(::CUDAnative.CompilerJob, ::Array{Tuple{String,Array{Base.StackTraces.StackFrame,1},Any},1}, ::LLVM.Module) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/validation.jl:122
 [5] check_ir(::CUDAnative.CompilerJob, ::LLVM.Module) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/validation.jl:111
 [6] macro expansion at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/driver.jl:188 [inlined]
 [7] macro expansion at /home/yingbo/.julia/packages/TimerOutputs/7zSea/src/TimerOutput.jl:216 [inlined]
 [8] codegen(::Symbol, ::CUDAnative.CompilerJob; libraries::Bool, dynamic_parallelism::Bool, optimize::Bool, strip::Bool, strict::Bool) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/driver.jl:186
 [9] compile(::Symbol, ::CUDAnative.CompilerJob; libraries::Bool, dynamic_parallelism::Bool, optimize::Bool, strip::Bool, strict::Bool) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/driver.jl:47
 [10] compile at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/compiler/driver.jl:28 [inlined]
 [11] macro expansion at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/execution.jl:389 [inlined]
 [12] cufunction(::typeof(Cassette.overdub), ::Type{Tuple{Cassette.Context{nametype(Ctx),Nothing,Nothing,GPUifyLoops.var"##PassType#425",Nothing,Cassette.DisableHooks},typeof(DiffEqGPU.qr_kernel),CUDAnative.CuDeviceArray{StaticArrays.SArray{Tuple{3,3},Float32,2,9},1,CUDAnative.AS.Global},CUDAnative.CuDeviceArray{Float32,2,CUDAnative.AS.Global},Int64,Type{StaticArrays.SArray{Tuple{3,3},Float32,2,9}}}}; name::String, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/yingbo/.julia/packages/CUDAnative/UWBIY/src/execution.jl:357
 [13] launch(::GPUifyLoops.CUDA, ::typeof(DiffEqGPU.qr_kernel), ::CuArray{StaticArrays.SArray{Tuple{3,3},Float32,2,9},1}, ::Vararg{Any,N} where N; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/yingbo/.julia/packages/GPUifyLoops/mjszO/src/GPUifyLoops.jl:125
 [14] macro expansion at /home/yingbo/.julia/packages/GPUifyLoops/mjszO/src/GPUifyLoops.jl:119 [inlined]
 [15] _ at /home/yingbo/.julia/dev/DiffEqGPU/src/DiffEqGPU.jl:208 [inlined]

...
```

@vchuravy do you mind to take a look?
